### PR TITLE
feat: bump FFmpeg to 6.1.1

### DIFF
--- a/install-deps.ps1
+++ b/install-deps.ps1
@@ -1,10 +1,11 @@
-$version = "ffmpeg-n6.0-latest-win64-lgpl-shared-6.0"
+$release = "autobuild-2023-12-31-12-55"
+$version = "ffmpeg-n6.1.1-win64-lgpl-shared-6.1"
 $localname = "win64"
 $archive = "$version.zip"
 $dest = ".\libs\ffmpeg"
 
 $ProgressPreference = 'SilentlyContinue' # https://stackoverflow.com/q/28682642
-Invoke-WebRequest https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/$archive -OutFile $archive
+Invoke-WebRequest https://github.com/BtbN/FFmpeg-Builds/releases/download/$release/$archive -OutFile $archive
 
 Expand-Archive .\$archive -DestinationPath $dest
 

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-VERSION=ffmpeg-n6.0-latest-linux64-lgpl-shared-6.0
+RELEASE=autobuild-2023-12-31-12-55
+VERSION=ffmpeg-n6.1.1-linux64-lgpl-shared-6.1
 LOCALNAME=linux64
 ARCHIVE=$VERSION.tar.xz
 DEST=./libs/ffmpeg
 
-wget -O $ARCHIVE https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/$ARCHIVE && \
+wget -O $ARCHIVE https://github.com/BtbN/FFmpeg-Builds/releases/download/$RELEASE/$ARCHIVE && \
   tar xf $ARCHIVE -C $DEST && \
   rm $ARCHIVE && \
   rm -rf $DEST/$LOCALNAME && \


### PR DESCRIPTION
The download link in the build script is expected to be valid for two years.