### PR TITLE
fix: exception on FFmpeg proxy file creation

### DIFF
--- a/src/Aurio.FFmpeg.UnitTest/Aurio.FFmpeg.UnitTest.csproj
+++ b/src/Aurio.FFmpeg.UnitTest/Aurio.FFmpeg.UnitTest.csproj
@@ -18,6 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aurio.FFmpeg.UnitTest/FFmpegSourceStreamTests.cs
+++ b/src/Aurio.FFmpeg.UnitTest/FFmpegSourceStreamTests.cs
@@ -17,9 +17,11 @@ namespace Aurio.FFmpeg.UnitTest
             Assert.Throws<ArgumentNullException>(act);
         }
 
-        [Fact]
-        public void SuggestWaveProxyFileInfo_WithoutDirectory()
+        [SkippableFact]
+        public void SuggestWaveProxyFileInfo_WithoutDirectory_Windows()
         {
+            Skip.IfNot(OperatingSystem.IsWindows());
+
             var fileInfo = new FileInfo("X:\\folder\\file.wav");
 
             var proxyFileInfo = FFmpegSourceStream.SuggestWaveProxyFileInfo(fileInfo);
@@ -27,9 +29,23 @@ namespace Aurio.FFmpeg.UnitTest
             Assert.Equal("X:\\folder\\file.wav.ffproxy.wav", proxyFileInfo.FullName);
         }
 
-        [Fact]
-        public void SuggestWaveProxyFileInfo_WithDirectory()
+        [SkippableFact]
+        public void SuggestWaveProxyFileInfo_WithoutDirectory_Unix()
         {
+            Skip.If(OperatingSystem.IsWindows());
+
+            var fileInfo = new FileInfo("/folder/file.wav");
+
+            var proxyFileInfo = FFmpegSourceStream.SuggestWaveProxyFileInfo(fileInfo);
+
+            Assert.Equal("/folder/file.wav.ffproxy.wav", proxyFileInfo.FullName);
+        }
+
+        [SkippableFact]
+        public void SuggestWaveProxyFileInfo_WithDirectory_Windows()
+        {
+            Skip.IfNot(OperatingSystem.IsWindows());
+
             var fileInfo = new FileInfo("X:\\folder\\file.wav");
             var directoryInfo = new DirectoryInfo("Y:\\temp\\dir");
 
@@ -40,6 +56,25 @@ namespace Aurio.FFmpeg.UnitTest
 
             Assert.Equal(
                 "Y:\\temp\\dir\\87c18cf1c8d8e07552df4ecc1ef629995fca9c59ad47ccf7eb4816de33590af7.ffproxy.wav",
+                proxyFileInfo.FullName
+            );
+        }
+
+        [SkippableFact]
+        public void SuggestWaveProxyFileInfo_WithDirectory_Unix()
+        {
+            Skip.If(OperatingSystem.IsWindows());
+
+            var fileInfo = new FileInfo("/folder/file.wav");
+            var directoryInfo = new DirectoryInfo("/temp/dir");
+
+            var proxyFileInfo = FFmpegSourceStream.SuggestWaveProxyFileInfo(
+                fileInfo,
+                directoryInfo
+            );
+
+            Assert.Equal(
+                "/temp/dir/e2c5b9282d156c5bdbf95639ca2ce2516b096e4828b7aa16620cb317cc90b3d9.ffproxy.wav",
                 proxyFileInfo.FullName
             );
         }

--- a/src/Aurio.FFmpeg.UnitTest/FFmpegSourceStreamTests.cs
+++ b/src/Aurio.FFmpeg.UnitTest/FFmpegSourceStreamTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using Xunit;
+
+namespace Aurio.FFmpeg.UnitTest
+{
+    public class FFmpegSourceStreamTests
+    {
+        [Fact]
+        public void CreateWaveProxy_ProxyFileInfoIsNull()
+        {
+            FileInfo fileInfo = new("X:\\test.file");
+            FileInfo? proxyFileInfo = null;
+
+            void act() => FFmpegSourceStream.CreateWaveProxy(fileInfo, proxyFileInfo);
+
+            Assert.Throws<ArgumentNullException>(act);
+        }
+
+        [Fact]
+        public void SuggestWaveProxyFileInfo_WithoutDirectory()
+        {
+            var fileInfo = new FileInfo("X:\\folder\\file.wav");
+
+            var proxyFileInfo = FFmpegSourceStream.SuggestWaveProxyFileInfo(fileInfo);
+
+            Assert.Equal("X:\\folder\\file.wav.ffproxy.wav", proxyFileInfo.FullName);
+        }
+
+        [Fact]
+        public void SuggestWaveProxyFileInfo_WithDirectory()
+        {
+            var fileInfo = new FileInfo("X:\\folder\\file.wav");
+            var directoryInfo = new DirectoryInfo("Y:\\temp\\dir");
+
+            var proxyFileInfo = FFmpegSourceStream.SuggestWaveProxyFileInfo(
+                fileInfo,
+                directoryInfo
+            );
+
+            Assert.Equal(
+                "Y:\\temp\\dir\\87c18cf1c8d8e07552df4ecc1ef629995fca9c59ad47ccf7eb4816de33590af7.ffproxy.wav",
+                proxyFileInfo.FullName
+            );
+        }
+    }
+}

--- a/src/Aurio.FFmpeg/FFmpegAudioStreamFactory.cs
+++ b/src/Aurio.FFmpeg/FFmpegAudioStreamFactory.cs
@@ -31,6 +31,8 @@ namespace Aurio.FFmpeg
 
         public IAudioStream OpenFile(FileInfo fileInfo, FileInfo proxyFileInfo = null)
         {
+            proxyFileInfo ??= FFmpegSourceStream.SuggestWaveProxyFileInfo(fileInfo);
+
             if (FFmpegSourceStream.WaveProxySuggested(fileInfo))
             {
                 Console.WriteLine("File format with known seek problems, creating proxy file...");


### PR DESCRIPTION
Make sure that a proxy file info is set before triggering the proxy file generation.