### PR TITLE
feat: read FFmpeg samples without intermediary buffer

### DIFF
--- a/src/Aurio.FFmpeg/Aurio.FFmpeg.csproj
+++ b/src/Aurio.FFmpeg/Aurio.FFmpeg.csproj
@@ -12,6 +12,7 @@
     <FFmpegProxyLinuxPath>..\..\nativesrc\out\build\linux-$(FFmpegProxyBuildConfig)\aurioffmpegproxy</FFmpegProxyLinuxPath>
     <IsPackable>true</IsPackable>
     <Description>Extension library for Aurio, which provides audio decoding through FFmpeg (see https://ffmpeg.org/).</Description>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\Aurio.licenseheader" Link="Aurio.licenseheader" />


### PR DESCRIPTION
Use newer .NET API to read samples from native layer directly into managed memory and avoid the overhead of copying into a transfer buffer.