### PR TITLE
fix: infinite read loop at end of some FFmpeg streams

### DIFF
--- a/nativesrc/aurioffmpegproxy/main.c
+++ b/nativesrc/aurioffmpegproxy/main.c
@@ -34,7 +34,8 @@ int file_close(FILE* f) {
 }
 
 int file_read_packet(void* f, uint8_t* buf, int buf_size) {
-	return (int)fread(buf, 1, buf_size, f);
+	int bytesRead = (int)fread(buf, 1, buf_size, f);
+	return bytesRead > 0 ? bytesRead : AVERROR_EOF;
 }
 
 int64_t file_seek(void* f, int64_t offset, int whence) {

--- a/src/Aurio.FFmpeg/FFmpegReader.cs
+++ b/src/Aurio.FFmpeg/FFmpegReader.cs
@@ -24,6 +24,7 @@ namespace Aurio.FFmpeg
 {
     public class FFmpegReader : IDisposable
     {
+        private const int AVERROR_EOF = -('E' | ('O' << 8) | ('F' << 16) | (' ' << 24));
         private string filename; // store source filename for debugging
         private bool disposed = false;
         private Type mode;
@@ -86,6 +87,11 @@ namespace Aurio.FFmpeg
             {
                 var bufferSpan = new Span<byte>(buffer.ToPointer(), bufferSize);
                 int bytesRead = stream.Read(bufferSpan);
+
+                if (bytesRead <= 0)
+                {
+                    return AVERROR_EOF;
+                }
 
                 return bytesRead;
             };


### PR DESCRIPTION
When FFmpeg doesn't know from file metadata where a stream ends (e.g., MPEG transport streams), it tries to read until it reaches the end. To detect the end, it looks for a specific `EOF` code. Update the `read` function to return the `EOF` code instead of `0` (bytes read) and prevent FFmpeg from endlessly retrying to read.