### PR TITLE
FFmpeg seek improvements

### DIFF
--- a/src/Aurio.FFmpeg.UnitTest/AudioDecode.cs
+++ b/src/Aurio.FFmpeg.UnitTest/AudioDecode.cs
@@ -22,9 +22,10 @@ namespace Aurio.FFmpeg.UnitTest
             var s = new FFmpegSourceStream(
                 new FileInfo("./Resources/sine440-44100-16-mono-200ms.mp3")
             );
+            var expectedMinLength = 44100 * 0.2 * 4; // Fs * 200ms * sampleSize (min, because MP3 adds additional samples)
 
             var length = StreamUtil.ReadAllAndCount(s);
-            Assert.True(length > 46000);
+            Assert.True(length >= expectedMinLength);
         }
 
         [Fact]

--- a/src/Aurio.FFmpeg.UnitTest/Aurio.FFmpeg.UnitTest.csproj
+++ b/src/Aurio.FFmpeg.UnitTest/Aurio.FFmpeg.UnitTest.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Aurio.FFmpeg.UnitTest/FFmpegSourceStreamTests.cs
+++ b/src/Aurio.FFmpeg.UnitTest/FFmpegSourceStreamTests.cs
@@ -239,5 +239,30 @@ namespace Aurio.FFmpeg.UnitTest
                 Times.Exactly(3)
             );
         }
+
+        [Fact]
+        public void SeekBeyondEnd_PositionCanBeSet()
+        {
+            var fileInfo = new FileInfo("./Resources/sine440-44100-16-mono-200ms.ts");
+            var s = new FFmpegSourceStream(fileInfo);
+            var position = 10000000000 * s.SampleBlockSize;
+
+            s.Position = position;
+
+            Assert.Equal(position, s.Position);
+        }
+
+        [Fact]
+        public void SeekBeyondEnd_ReadIndicatesEndOfStream()
+        {
+            var fileInfo = new FileInfo("./Resources/sine440-44100-16-mono-200ms.ts");
+            var s = new FFmpegSourceStream(fileInfo);
+            var position = 10000000000 * s.SampleBlockSize;
+
+            s.Position = position;
+            var bytesRead = s.Read(new byte[1000], 0, 1000);
+
+            Assert.Equal(0, bytesRead);
+        }
     }
 }

--- a/src/Aurio.FFmpeg.UnitTest/FFmpegSourceStreamTests.cs
+++ b/src/Aurio.FFmpeg.UnitTest/FFmpegSourceStreamTests.cs
@@ -101,5 +101,14 @@ namespace Aurio.FFmpeg.UnitTest
 
             Assert.Equal(1000, s.Position);
         }
+
+        [Fact]
+        public void NonZeroStartTime_InitialPositionIsZero()
+        {
+            var fileInfo = new FileInfo("./Resources/sine440-44100-16-mono-200ms.ts");
+            var s = new FFmpegSourceStream(fileInfo);
+
+            Assert.Equal(0, s.Position);
+        }
     }
 }

--- a/src/Aurio.FFmpeg/FFmpegReader.cs
+++ b/src/Aurio.FFmpeg/FFmpegReader.cs
@@ -214,7 +214,7 @@ namespace Aurio.FFmpeg
             }
         }
 
-        public int ReadFrame(
+        public virtual int ReadFrame(
             out long timestamp,
             byte[] output_buffer,
             int output_buffer_size,

--- a/src/Aurio.FFmpeg/FFmpegSourceStream.cs
+++ b/src/Aurio.FFmpeg/FFmpegSourceStream.cs
@@ -142,7 +142,6 @@ namespace Aurio.FFmpeg
             catch (InvalidOperationException)
             {
                 readerFirstPTS = readerPosition;
-                readerPosition = 0;
                 Console.WriteLine("first PTS = " + readerFirstPTS);
             }
         }

--- a/src/Aurio.FFmpeg/FFmpegSourceStream.cs
+++ b/src/Aurio.FFmpeg/FFmpegSourceStream.cs
@@ -95,17 +95,7 @@ namespace Aurio.FFmpeg
             sourceBufferPosition = 0;
             sourceBufferLength = -1; // -1 means buffer empty, >= 0 means valid buffer data
 
-            // determine first PTS to handle cases where it is > 0
-            try
-            {
-                Position = 0;
-            }
-            catch (InvalidOperationException)
-            {
-                readerFirstPTS = readerPosition;
-                readerPosition = 0;
-                Console.WriteLine("first PTS = " + readerFirstPTS);
-            }
+            DetermineFirstPts();
 
             seekIndexCreated = false;
         }
@@ -132,6 +122,31 @@ namespace Aurio.FFmpeg
             get { return readerPosition + sourceBufferPosition - readerFirstPTS; }
         }
 
+        private void ReadFrame()
+        {
+            sourceBufferLength = reader.ReadFrame(
+                out readerPosition,
+                sourceBuffer,
+                sourceBuffer.Length,
+                out Type type
+            );
+        }
+
+        private void DetermineFirstPts()
+        {
+            // determine first PTS to handle cases where it is > 0
+            try
+            {
+                Position = 0;
+            }
+            catch (InvalidOperationException)
+            {
+                readerFirstPTS = readerPosition;
+                readerPosition = 0;
+                Console.WriteLine("first PTS = " + readerFirstPTS);
+            }
+        }
+
         /// <summary>
         /// Read frames (repeatedly) into the buffer until it contains the sample with the
         /// desired timestamp.
@@ -145,12 +160,7 @@ namespace Aurio.FFmpeg
 
             while (true)
             {
-                sourceBufferLength = reader.ReadFrame(
-                    out readerPosition,
-                    sourceBuffer,
-                    sourceBuffer.Length,
-                    out Type type
-                );
+                ReadFrame();
 
                 if (readerPosition == previousReaderPosition)
                 {


### PR DESCRIPTION
Fix multiple bugs related to the handling of the first PTS (non-zero start offset) and end of stream, and also works around an FFmpeg seek issue.